### PR TITLE
Insure that the file created is set to 0600

### DIFF
--- a/library/ssh_copy_id.py
+++ b/library/ssh_copy_id.py
@@ -182,6 +182,7 @@ def run_module():
         )
         file_handler.write(data)
         file_handler.flush()
+        file_handler.chmod(int('0600', 8))
         file_handler.close()
 
         result['message'] = 'SSH public key injected!'


### PR DESCRIPTION
The default was when the directory and the file created it follows the umask directive which may lead to an invalid file mode
"Authentication refused: bad ownership or modes for file /home/tester/.ssh/authorized_keys"