### PR TITLE
Add Hetzner storage-box support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Below are the available varaibles you will need to supply to the role.
 | username | username to connect to remote system |
 | password | password to connect to remote system |
 | ssh_public_key | public key file (absolute path) to set into remote system |
-| hetzner_storagebox | if set to true allows copying keys to Hetzner storage box (without this it fails) |
 | port | SSH port to connect to |
 
 Example Playbook
@@ -39,13 +38,13 @@ SSH key based authentication configured.
   hosts: localhost
 
   roles:
-    - role: rywillia.ssh-copy-id
+    - role: ryankwilliams.ssh_copy_id
       vars:
         hostname: 127.0.0.1
         username: username
         password: password
         ssh_public_key: /home/username/.ssh/id_rsa.pub
-	hetzner_storagebox: true
+        hetzner_storagebox: true
         ssh_port: 22
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Below are the available varaibles you will need to supply to the role.
 | username | username to connect to remote system |
 | password | password to connect to remote system |
 | ssh_public_key | public key file (absolute path) to set into remote system |
+| hetzner_storagebox | if set to true allows copying keys to Hetzner storage box (without this it fails) |
 | port | SSH port to connect to |
 
 Example Playbook
@@ -38,12 +39,13 @@ SSH key based authentication configured.
   hosts: localhost
 
   roles:
-    - role: ryankwilliams.ssh_copy_id
+    - role: rywillia.ssh-copy-id
       vars:
         hostname: 127.0.0.1
         username: username
         password: password
         ssh_public_key: /home/username/.ssh/id_rsa.pub
+	hetzner_storagebox: true
         ssh_port: 22
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,6 @@
 
 # ssh port
 ssh_port: 22
+
+# is the destination Hetzner Storage Box?
+hetzner_storagebox: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,4 +7,5 @@
     username: "{{ username }}"
     password: "{{ password }}"
     ssh_public_key: "{{ ssh_public_key }}"
+    hetzner_storagebox: "{{ hetzner_storagebox }}"
     ssh_port: "{{ ssh_port }}"


### PR DESCRIPTION
Faced issues when using this role on Hetzner Storage Box. This PR adds a way to manage keys on Hetzner Storage Boxes without breaking original workflow. 