### PR TITLE
Add auth_key directory for root user

### DIFF
--- a/library/ssh_copy_id.py
+++ b/library/ssh_copy_id.py
@@ -117,6 +117,7 @@ def run_module():
     else:
         if username == 'root':
             base_dir = '/root/'
+            auth_key = join(base_dir, '.ssh/authorized_keys')
         else:
             base_dir = '/home/%s' % username
             auth_key = join(base_dir, '.ssh/authorized_keys')


### PR DESCRIPTION
Build directory structure for the case when an SSH public key needs to be transferred for the root user on remote host.
Otherwise, the operation fails with the 
```
UserWarning: Unknown ssh-ed25519 host key for
...
UnboundLocalError: local variable 'auth_key' referenced before assignment
```